### PR TITLE
Fix the R_dev_news name displayed

### DIFF
--- a/11-news_and_announcements.Rmd
+++ b/11-news_and_announcements.Rmd
@@ -22,4 +22,4 @@ Updates about conferences actively supported or endorsed by The R Foundation can
 
 ## Twitter
 
-Follow ['\@R_dev_news'](https://twitter.com/R_dev_news) on Twitter for the [R development updates](https://developer.r-project.org/RSSfeeds.html) and [blog post](https://developer.r-project.org/Blog/public/) announcements.
+Follow [\@R_dev_news](https://twitter.com/R_dev_news) on Twitter for the [R development updates](https://developer.r-project.org/RSSfeeds.html) and [blog post](https://developer.r-project.org/Blog/public/) announcements.


### PR DESCRIPTION
Fix the display of R_dev_nes but removing the quotations. (Mentioned on https://github.com/forwards/rcontribution/issues/14) 

The git diff is large but I have just modified that line. Not sure what is going on. 